### PR TITLE
Change godi tag for autowire

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This should output:
 `"CVT Module simulating gear..."`
 
 ## AutoWire support
-Using the `autowired` tag in a struct field allows the injector to automatically construct the object by using the `AutoWire` function
+Using the `godi:"autowired"` tag in a struct field allows the injector to automatically construct the object by using the `AutoWire` function
 ```go
 import "github.com/mylux/godi/container"
 
@@ -60,7 +60,7 @@ func (c Civic) ShiftGear(){
 }
 
 type Person struct {
- DailyVehicle Car `autowired:""`
+ DailyVehicle Car `godi:"autowired"`
  RoadTripVehicle Car
 }
 
@@ -203,9 +203,9 @@ func (c Civic) ShiftGear(){
 }
 
 type Person struct {
-  DailyDriver Car                 `autowired:""`
-  RoadTrip    Car                 `autowired:""`
-  IdDoc       NationalIdDocument  `autowired:""`
+  DailyDriver Car                 `godi:"autowired"`
+  RoadTrip    Car                 `godi:"autowired"`
+  IdDoc       NationalIdDocument  `godi:"autowired"`
 }
 
 ```

--- a/container/container.go
+++ b/container/container.go
@@ -3,7 +3,12 @@ package container
 import (
 	"fmt"
 	"reflect"
+	"slices"
+	"strings"
 )
+
+const godiTagName = "godi"
+const godiAutoWireTagValue = "autowired"
 
 var registry map[reflect.Type]interface{} = map[reflect.Type]interface{}{}
 
@@ -57,7 +62,7 @@ func AutoWire(obj interface{}) error {
 
 	for i := 0; i < oType.NumField(); i++ {
 		field := oType.Field(i)
-		if _, exists := field.Tag.Lookup("autowired"); exists {
+		if isAutoWire(field) {
 			fieldType := field.Type
 			constructedItems, err := construct(fieldType)
 			if err != nil {
@@ -107,6 +112,13 @@ func CleanRegistry() {
 		delete(registry, t)
 	}
 
+}
+
+func isAutoWire(field reflect.StructField) bool {
+	if v, exists := field.Tag.Lookup(godiTagName); exists {
+		return slices.Contains(strings.Split(v, ","), godiAutoWireTagValue)
+	}
+	return false
 }
 
 func findImplementation(constructor interface{}, t reflect.Type) reflect.Type {

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -53,8 +53,8 @@ func createLogger(t LoggerType) Logger {
 }
 
 type ManyLoggers struct {
-	L1 Logger `autowired:""`
-	L2 Logger `autowired:""`
+	L1 Logger `godi:"autowired"`
+	L2 Logger `godi:"autowired"`
 	L3 Logger
 }
 
@@ -62,9 +62,9 @@ type LogAssistant struct {
 }
 
 type ManyLoggersWithNoInterfaceFields struct {
-	L1 Logger       `autowired:""`
-	L2 Logger       `autowired:""`
-	A  LogAssistant `autowired:""`
+	L1 Logger       `godi:"autowired"`
+	L2 Logger       `godi:"autowired"`
+	A  LogAssistant `godi:"autowired"`
 }
 
 func setUp() {


### PR DESCRIPTION
Better make the tag `godi` and the `autowire` word as one of the many values accepted within it (separated by comas for future possible other configurations)